### PR TITLE
initialize layout

### DIFF
--- a/src/app/kanban/kanban-card/kanban-card.component.html
+++ b/src/app/kanban/kanban-card/kanban-card.component.html
@@ -1,0 +1,3 @@
+<div class="card">
+    {{ card.details }}
+</div>

--- a/src/app/kanban/kanban-card/kanban-card.component.spec.ts
+++ b/src/app/kanban/kanban-card/kanban-card.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { KanbanCardComponent } from './kanban-card.component';
+
+describe('KanbanCardComponent', () => {
+  let component: KanbanCardComponent;
+  let fixture: ComponentFixture<KanbanCardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ KanbanCardComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KanbanCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kanban/kanban-card/kanban-card.component.ts
+++ b/src/app/kanban/kanban-card/kanban-card.component.ts
@@ -1,0 +1,18 @@
+import { KanbanCard } from './kanban-card.model';
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-kanban-card',
+  templateUrl: './kanban-card.component.html',
+  styleUrls: ['./kanban-card.component.scss']
+})
+export class KanbanCardComponent implements OnInit {
+
+  @Input() card: KanbanCard;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/kanban/kanban-card/kanban-card.model.ts
+++ b/src/app/kanban/kanban-card/kanban-card.model.ts
@@ -1,0 +1,7 @@
+export class KanbanCard {
+    details: string;
+
+    constructor(data: Partial<KanbanCard>) {
+        Object.assign(this, data);
+    }
+}

--- a/src/app/kanban/kanban-column/kanban-column.component.html
+++ b/src/app/kanban/kanban-column/kanban-column.component.html
@@ -1,0 +1,8 @@
+<div class="column">
+    <header class="column-header">
+        {{ column.title }}
+    </header>
+    <main class="column-body">
+        <app-kanban-card *ngFor="let card of column.cards" [card]="card"></app-kanban-card>
+    </main>
+</div>

--- a/src/app/kanban/kanban-column/kanban-column.component.scss
+++ b/src/app/kanban/kanban-column/kanban-column.component.scss
@@ -1,0 +1,17 @@
+:host {
+    .column {
+        margin: 1em;
+        padding: 0 1em;
+        border: 1px solid #eee;
+        box-shadow: 0px 1px 3px #ddd;
+    }
+
+    .column-header {
+        font-size: 32px;
+        padding: 0.25em 0;
+    }
+
+    .column-body {
+        padding-bottom: 1em;
+    }
+}

--- a/src/app/kanban/kanban-column/kanban-column.component.spec.ts
+++ b/src/app/kanban/kanban-column/kanban-column.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { KanbanColumnComponent } from './kanban-column.component';
+
+describe('KanbanColumnComponent', () => {
+  let component: KanbanColumnComponent;
+  let fixture: ComponentFixture<KanbanColumnComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ KanbanColumnComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KanbanColumnComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kanban/kanban-column/kanban-column.component.ts
+++ b/src/app/kanban/kanban-column/kanban-column.component.ts
@@ -1,0 +1,19 @@
+import { KanbanColumn } from './kanban-column.model';
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-kanban-column',
+  templateUrl: './kanban-column.component.html',
+  styleUrls: ['./kanban-column.component.scss']
+})
+export class KanbanColumnComponent implements OnInit {
+
+  @Input() column: KanbanColumn;
+
+  constructor() { }
+
+  ngOnInit(): void {
+    console.log(this.column);
+  }
+
+}

--- a/src/app/kanban/kanban-column/kanban-column.model.ts
+++ b/src/app/kanban/kanban-column/kanban-column.model.ts
@@ -1,0 +1,9 @@
+import { KanbanCard } from './../kanban-card/kanban-card.model';
+export class KanbanColumn {
+    title: string;
+    cards: KanbanCard[] = [];
+
+    constructor(data: Partial<KanbanColumn>) {
+        Object.assign(this, data);
+    }
+}

--- a/src/app/kanban/kanban.component.html
+++ b/src/app/kanban/kanban.component.html
@@ -1,0 +1,3 @@
+<div class="container">
+    <app-kanban-column *ngFor="let column of columns" [column]="column"></app-kanban-column>
+</div>

--- a/src/app/kanban/kanban.component.scss
+++ b/src/app/kanban/kanban.component.scss
@@ -1,0 +1,8 @@
+:host {
+    .container {
+        display: grid;
+        height: 100%;
+
+        grid-template-columns: 1fr 1fr 1fr;
+    }
+}

--- a/src/app/kanban/kanban.component.spec.ts
+++ b/src/app/kanban/kanban.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { KanbanComponent } from './kanban.component';
+
+describe('KanbanComponent', () => {
+  let component: KanbanComponent;
+  let fixture: ComponentFixture<KanbanComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ KanbanComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KanbanComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kanban/kanban.component.ts
+++ b/src/app/kanban/kanban.component.ts
@@ -1,0 +1,35 @@
+import { KanbanColumn } from './kanban-column/kanban-column.model';
+import { Component, OnInit } from '@angular/core';
+import { KanbanCard } from './kanban-card/kanban-card.model';
+
+@Component({
+  selector: 'app-kanban',
+  templateUrl: './kanban.component.html',
+  styleUrls: ['./kanban.component.scss']
+})
+export class KanbanComponent implements OnInit {
+
+  columns: KanbanColumn[] = [{
+    title: 'Planned',
+    cards: [{
+      details: 'Make the Kanban board'
+    }, {
+      details: 'Push to GitHub'
+    }]
+  }, {
+    title: 'In Progress',
+    cards: [{
+      details: 'Yeehaw'
+    }]
+  }, {
+    title: 'Done',
+    cards: []
+  }];
+
+  constructor() { }
+
+  ngOnInit(): void {
+    console.log(this.columns);
+  }
+
+}


### PR DESCRIPTION
Create the basic layout for a kanban board with components accepting models defining the kanban content so they can be dynamically populated in the future.

# Progress
![image](https://user-images.githubusercontent.com/7821335/97649928-28284180-1a1e-11eb-9838-20a86cb7bccf.png)
